### PR TITLE
More generic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM almondsh/almond:coursier
+
+USER $NB_UID
+
+ARG ALMOND_VERSION
+
+# Set to a single Scala version string or list of Scala versions separated by a space.
+# i.e SCALA_VERSIONS="2.11.12 2.12.8"
+ARG SCALA_VERSIONS
+
+RUN [ -z "$SCALA_VERSIONS" ] && echo "SCALA_VERSIONS is empty" && exit 1; \
+    [ -z "$ALMOND_VERSION" ] && echo "ALMOND_VERSION is empty" && exit 1; \
+    for SCALA_FULL_VERSION in $SCALA_VERSIONS; do \
+        # remove patch version
+        SCALA_MAJOR_VERSION=${SCALA_FULL_VERSION%.*}; \
+        # remove all dots for the kernel id
+        SCALA_MAJOR_VERSION_TRIMMED=$(echo $SCALA_MAJOR_VERSION | tr -d .); \
+        echo Installing almond $ALMOND_VERSION for Scala $SCALA_FULL_VERSION; \
+        coursier bootstrap \
+            -r jitpack \
+            -i user -I user:sh.almond:scala-kernel-api_$SCALA_FULL_VERSION:$ALMOND_VERSION \
+            sh.almond:scala-kernel_$SCALA_FULL_VERSION:$ALMOND_VERSION \
+            --default=true --sources \
+            -o almond && \
+        ./almond --install --log info --metabrowse --id scala$SCALA_MAJOR_VERSION_TRIMMED --display-name "Scala $SCALA_MAJOR_VERSION" && \
+        rm -f almond; \
+    done

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+source ./vars.sh
+
+docker build --build-arg ALMOND_VERSION=$ALMOND_VERSION --build-arg SCALA_VERSIONS="$SCALA211_VERSION $SCALA212_VERSION" -t $IMAGE_NAME .
+docker build --build-arg ALMOND_VERSION=$ALMOND_VERSION --build-arg SCALA_VERSIONS="$SCALA211_VERSION" -t $IMAGE_NAME-scala-$SCALA211_VERSION .
+docker build --build-arg ALMOND_VERSION=$ALMOND_VERSION --build-arg SCALA_VERSIONS="$SCALA212_VERSION" -t $IMAGE_NAME-scala-$SCALA212_VERSION .

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+git clone https://github.com/almond-sh/almond.git -b $SOURCE_BRANCH  --depth 1

--- a/hooks/push
+++ b/hooks/push
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+source ./vars.sh
+
+docker push $IMAGE_NAME-scala-$SCALA211_VERSION
+docker push $IMAGE_NAME-scala-$SCALA212_VERSION
+docker push $IMAGE_NAME
+
+docker tag $IMAGE_NAME $DOCKER_REPO:latest
+docker push $DOCKER_REPO:latest

--- a/vars.sh
+++ b/vars.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export SCALA212_VERSION="$(grep -oP '(?<=def scala212 = ")[^"]*(?<!")' almond/project/Settings.scala)"
+export SCALA211_VERSION="$(grep -oP '(?<=def scala211 = ")[^"]*(?<!")' almond/project/Settings.scala)"
+export ALMOND_VERSION="$(git -C almond describe --tags --abbrev=0 --match 'v*' | sed 's/^v//')"


### PR DESCRIPTION
I've created a dockerfile that should make it easier to build images with kernels for a single or multiple Scala versions. You just have to pass `SCALA_VERSIONS` to the docker build and it will create an image containing a kernel for each version (if it's published to maven).

I've also added a few [docker hub build hooks](https://docs.docker.com/docker-hub/builds/advanced/). Given an almond version tag, it builds three images, one for Scala 2.11, one for 2.12 and one with kernels for both versions. You can see this working in my [test repo](https://cloud.docker.com/repository/docker/sbrunk/almond-docker-images).

If your agree to switch to this variant, I could also prepare a PR for updating `update-docker-images.sh` script in the main repo to just set the almond version tag here (we still have to wait until the artifacts are on maven central). Another possible variant would be to just build the docker image from the local artifacts via travis and then push it to docker hub.